### PR TITLE
[002-STORE] 점포 등록, 점포 검색, 점포정보 조회, 점포정보 수정, 점포정보 삭제 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/mytable/controller/StoreController.java
+++ b/src/main/java/com/zerobase/mytable/controller/StoreController.java
@@ -1,0 +1,58 @@
+package com.zerobase.mytable.controller;
+
+import com.zerobase.mytable.dto.StoreDto;
+import com.zerobase.mytable.dto.StoreRegisterDto;
+import com.zerobase.mytable.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/store")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    // 점포 등록
+    @PostMapping("/register")
+    @PreAuthorize("hasRole('PARTNER')")
+    public StoreRegisterDto.Response storeRegister(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @Valid @RequestBody StoreRegisterDto.Request request) {
+        return storeService.register(token, request);
+    }
+
+    // 점포 검색 시 10개 자동완성
+    @GetMapping("/autocomplete")
+    public List<String> autocomplete(@RequestParam String keyword) {
+        return storeService.autoComplete(keyword);
+    }
+
+    // 점포 정보 조회
+    @GetMapping("/info")
+    public StoreDto getStoreInfo(@RequestParam String storename) {
+        return storeService.getStoreInfo(storename);
+    }
+
+    // 점포 정보 수정
+    @PutMapping("/info/update")
+    @PreAuthorize("hasRole('PARTNER')")
+    public StoreDto updateStoreInfo(@RequestHeader(name = "X-AUTH-TOKEN") String token,
+                                    @RequestParam String existingStorename,
+                                    @Valid @RequestBody StoreRegisterDto.Request updateRequest) {
+        return storeService.updateStoreInfo(token, existingStorename, updateRequest);
+    }
+
+    // 점포 삭제
+    @DeleteMapping("/info/delete")
+    @PreAuthorize("hasRole('PARTNER')")
+    public StoreRegisterDto.Response deleteStore(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String storename) {
+        return storeService.deleteStore(token, storename);
+    }
+}

--- a/src/main/java/com/zerobase/mytable/domain/Customer.java
+++ b/src/main/java/com/zerobase/mytable/domain/Customer.java
@@ -102,7 +102,7 @@ public class Customer extends BaseEntity implements UserDetails {
                 .password(request.getPassword())
                 .phone(request.getPhone())
                 .birth(request.getBirth())
-                .roles(Collections.singletonList(UserType.CUSTOMER.toString()))
+                .roles(Collections.singletonList(UserType.ROLE_CUSTOMER.toString()))
                 .build();
     }
 }

--- a/src/main/java/com/zerobase/mytable/domain/Partner.java
+++ b/src/main/java/com/zerobase/mytable/domain/Partner.java
@@ -30,7 +30,7 @@ public class Partner extends BaseEntity implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // id는 인덱스로 사용되기 때문에 고유 식별자 사용
+    // id는 인덱스로 사용되어 파트너 가입자 수 노출 될 수 있기 때문에 고유 식별자 사용
     @Column(unique = true, nullable = false)
     private String uid;
 
@@ -103,7 +103,7 @@ public class Partner extends BaseEntity implements UserDetails {
                 .password(request.getPassword())
                 .phone(request.getPhone())
                 .birth(request.getBirth())
-                .roles(Collections.singletonList(UserType.PARTNER.toString()))
+                .roles(Collections.singletonList(UserType.ROLE_PARTNER.toString()))
                 .build();
     }
 }

--- a/src/main/java/com/zerobase/mytable/domain/Store.java
+++ b/src/main/java/com/zerobase/mytable/domain/Store.java
@@ -1,0 +1,60 @@
+package com.zerobase.mytable.domain;
+
+import com.zerobase.mytable.dto.StoreRegisterDto;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class Store extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String storename;
+
+    @Column
+    private String phone;
+
+    // 점포 입력 받을 때 주소 입력(추후 통계 처리할 경우를 위해 시도/ 시군구/ 도로명 / 상세주소로 나눠서 받음)
+    @Column(nullable = false)
+    private String sido;
+
+    @Column(nullable = false)
+    private String sigungu;
+
+    @Column(nullable = false)
+    private String roadname;
+
+    @Column(nullable = false)
+    private String detailAddress;
+
+    // 상점에 대한 설명 입력
+    @Column(nullable = false)
+    private String description;
+
+    @ManyToOne
+    private Partner partner;
+
+    public static Store from(StoreRegisterDto.Request request){
+        return Store.builder()
+                .storename(request.getStorename())
+                .phone(request.getPhone())
+                .sido(request.getSido())
+                .sigungu(request.getSigungu())
+                .roadname(request.getRoadname())
+                .detailAddress(request.getDetailAddress())
+                .description(request.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/mytable/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/mytable/dto/StoreDto.java
@@ -1,0 +1,39 @@
+package com.zerobase.mytable.dto;
+
+import com.zerobase.mytable.domain.Store;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StoreDto {
+
+    private String storename;
+
+    private String phone;
+
+    private String sido;
+
+    private String sigungu;
+
+    private String roadname;
+
+    private String detailAddress;
+
+    private String description;
+
+    public static StoreDto from(Store store){
+        return StoreDto.builder()
+                .storename(store.getStorename())
+                .phone(store.getPhone())
+                .sido(store.getSido())
+                .sigungu(store.getSigungu())
+                .roadname(store.getRoadname())
+                .detailAddress(store.getDetailAddress())
+                .description(store.getDescription())
+                .build();
+    }
+
+}

--- a/src/main/java/com/zerobase/mytable/dto/StoreRegisterDto.java
+++ b/src/main/java/com/zerobase/mytable/dto/StoreRegisterDto.java
@@ -1,0 +1,49 @@
+package com.zerobase.mytable.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+public class StoreRegisterDto {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Builder
+    public static class Request{
+
+        @NotNull(message = "반드시 값이 있어야 합니다.")
+        private String storename;
+
+        @Pattern(regexp = "^0([0-9]{1,3}?)-?([0-9]{3,4})-?([0-9]{4})$",
+                message = "전화번호가 유효하지 않습니다.")
+        private String phone;
+
+        @NotNull(message = "반드시 값이 있어야 합니다.")
+        private String sido;
+
+        @NotNull(message = "반드시 값이 있어야 합니다.")
+        private String sigungu;
+
+        @NotNull(message = "반드시 값이 있어야 합니다.")
+        private String roadname;
+
+        @NotNull(message = "반드시 값이 있어야 합니다.")
+        private String detailAddress;
+
+        @NotNull(message = "반드시 값이 있어야 합니다.")
+        private String description;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+        private boolean success;
+        private int code;
+        private String msg;
+    }
+}

--- a/src/main/java/com/zerobase/mytable/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/zerobase/mytable/exception/CustomAccessDeniedHandler.java
@@ -1,5 +1,8 @@
 package com.zerobase.mytable.exception;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.mytable.dto.CustomErrorResponse;
+import com.zerobase.mytable.type.ErrorCode;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -15,6 +18,17 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.sendRedirect("/sign-in");
+
+        response.setStatus(400);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        CustomErrorResponse errorResponse = CustomErrorResponse.builder().errorCode(ErrorCode.ACCESS_DENIED)
+                .errorMessage(ErrorCode.ACCESS_DENIED.getDescription())
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String error = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(error);
     }
 }

--- a/src/main/java/com/zerobase/mytable/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/mytable/repository/StoreRepository.java
@@ -1,0 +1,17 @@
+package com.zerobase.mytable.repository;
+
+import com.zerobase.mytable.domain.Store;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    Optional<Store> findByStorename(String storename);
+
+    List<Store> findByStorenameContains(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/zerobase/mytable/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/mytable/security/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.zerobase.mytable.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -11,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/zerobase/mytable/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/mytable/security/SecurityConfiguration.java
@@ -2,11 +2,12 @@ package com.zerobase.mytable.security;
 
 import com.zerobase.mytable.exception.CustomAccessDeniedHandler;
 import com.zerobase.mytable.exception.CustomAuthenticationEntryPoint;
-import com.zerobase.mytable.type.UserType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -16,6 +17,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableWebSecurity
 public class SecurityConfiguration {
 
     private final TokenProvider tokenProvider;
@@ -32,10 +35,7 @@ public class SecurityConfiguration {
                 .and()
                     // 애플리케이션에 들어오는 요청에 대한 사용 권한을 체크, url마다 설정 가능
                     .authorizeRequests()
-                    .antMatchers("/sign-up/**", "/sign-in/**", "/review").permitAll()
-                    .antMatchers("/customer/**").hasRole(UserType.CUSTOMER.toString())
-                    .antMatchers("/partner/**").hasRole(UserType.PARTNER.toString())
-
+                    .anyRequest().permitAll()
                 .and()
                     // 권한 확인 과정에서 통과하지 못하는 예외가 발생할 경우 예외 전달
                     .exceptionHandling()

--- a/src/main/java/com/zerobase/mytable/service/StoreService.java
+++ b/src/main/java/com/zerobase/mytable/service/StoreService.java
@@ -1,0 +1,124 @@
+package com.zerobase.mytable.service;
+
+import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.dto.StoreDto;
+import com.zerobase.mytable.dto.StoreRegisterDto;
+import com.zerobase.mytable.exception.CustomException;
+import com.zerobase.mytable.repository.PartnerRepository;
+import com.zerobase.mytable.repository.StoreRepository;
+import com.zerobase.mytable.security.TokenProvider;
+import com.zerobase.mytable.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class StoreService {
+
+    private StoreRepository storeRepository;
+    private PartnerRepository partnerRepository;
+    private TokenProvider tokenProvider;
+
+    // 점포 등록
+    public StoreRegisterDto.Response register(String token, StoreRegisterDto.Request request) {
+        if (storeRepository.findByStorename(request.getStorename()).isPresent()) {
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_STORENAME);
+        }
+
+        Store requestStore = Store.from(request);
+        requestStore.setPartner(partnerRepository.getByUid(tokenProvider.getUid(token)));
+
+        Store savedStore = storeRepository.save(requestStore);
+
+        StoreRegisterDto.Response response = new StoreRegisterDto.Response();
+
+        if (!savedStore.getStorename().isEmpty()){
+            setSuccessResult(response);
+        } else {
+            setFailResult(response);
+        }
+
+        return response;
+    }
+
+    // 점포 검색 시 키워드 포함하는 10개 검색어 자동완성
+    public List<String> autoComplete(String keyword) {
+        Pageable limit = PageRequest.of(0, 10);
+        List<Store> stores = storeRepository.findByStorenameContains(keyword, limit);
+        return stores.stream()
+                .map(Store::getStorename)
+                .collect(Collectors.toList());
+    }
+
+    // 점포 정보 조회
+    public StoreDto getStoreInfo(String storename) {
+        return StoreDto.from(getStore(storename));
+    }
+
+    // 점포 정보 수정(점포에 해당하는 파트너 일치 여부 확인 후 처리)
+    public StoreDto updateStoreInfo(String token, String existingStorename,
+                                    StoreRegisterDto.Request updateRequest) {
+        Store store = getStore(existingStorename);
+
+        partnerValidate(token, store);
+
+        if (storeRepository.findByStorename(updateRequest.getStorename()).isPresent()) {
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_STORENAME);
+        }
+
+        store.setStorename(updateRequest.getStorename());
+        store.setPhone(updateRequest.getPhone());
+        store.setSido(updateRequest.getSido());
+        store.setSigungu(updateRequest.getSigungu());
+        store.setRoadname(updateRequest.getRoadname());
+        store.setDetailAddress(updateRequest.getDetailAddress());
+        store.setDescription(updateRequest.getDescription());
+
+        return StoreDto.from(storeRepository.save(store));
+    }
+
+    // 점포 삭제
+    public StoreRegisterDto.Response deleteStore(String token, String storename) {
+        Store store = getStore(storename);
+
+        partnerValidate(token, store);
+
+        storeRepository.delete(store);
+
+        StoreRegisterDto.Response response = new StoreRegisterDto.Response();
+        setSuccessResult(response);
+
+        return response;
+    }
+
+    private Store getStore(String storename) {
+        return storeRepository.findByStorename(storename)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_STORE));
+    }
+
+
+    private void setSuccessResult(StoreRegisterDto.Response response) {
+        response.setSuccess(true);
+        response.setCode(0);
+        response.setMsg("요청 성공");
+    }
+
+    private void setFailResult(StoreRegisterDto.Response response) {
+        response.setSuccess(false);
+        response.setCode(-1);
+        response.setMsg("요청 실패");
+    }
+
+    private void partnerValidate(String token, Store store){
+        if (!store.getPartner().getUid().equals(tokenProvider.getUid(token))) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/zerobase/mytable/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/mytable/type/ErrorCode.java
@@ -8,11 +8,17 @@ import lombok.Getter;
 public enum ErrorCode {
     // 토큰 관련
     INVALID_TOKEN("유효하지 않은 토큰입니다."),
+    ACCESS_DENIED("접근 권한이 없습니다."),
 
     // 회원가입 관련
     ALREADY_EMAIL_EXIST("이미 존재하는 이메일입니다."),
     NOT_FOUND_USER("존재하지 않는 회원입니다."),
-    INCORRECT_PASSWORD("패스워드가 일치하지 않습니다.");
+    INCORRECT_PASSWORD("패스워드가 일치하지 않습니다."),
+
+    // 점포 등록 관련
+    ALREADY_REGISTERED_STORENAME("이미 존재하는 점포명입니다."),
+    NOT_FOUND_STORE("존재하지 않는 점포입니다.");
+
 
     private final String description;
 }

--- a/src/main/java/com/zerobase/mytable/type/UserType.java
+++ b/src/main/java/com/zerobase/mytable/type/UserType.java
@@ -1,6 +1,6 @@
 package com.zerobase.mytable.type;
 
 public enum UserType {
-    PARTNER,
-    CUSTOMER;
+    ROLE_PARTNER,
+    ROLE_CUSTOMER;
 }

--- a/src/test/java/com/zerobase/mytable/controller/SignInControllerTest.java
+++ b/src/test/java/com/zerobase/mytable/controller/SignInControllerTest.java
@@ -5,10 +5,10 @@ import com.zerobase.mytable.dto.SignInDto;
 import com.zerobase.mytable.service.SignInService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -18,7 +18,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(SignInController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 class SignInControllerTest {
 
     @MockBean
@@ -32,7 +33,6 @@ class SignInControllerTest {
 
     // 파트너 로그인 성공
     @Test
-    @WithMockUser
     void successPartnerSignIn() throws Exception {
         //given
         SignInDto.Response response = new SignInDto.Response();
@@ -50,8 +50,7 @@ class SignInControllerTest {
         //then
         mockMvc.perform(post("/sign-in/partner")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestJson)
-                        .with(csrf()))
+                        .content(requestJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value(0))
@@ -60,7 +59,6 @@ class SignInControllerTest {
 
     // 고객 로그인 성공
     @Test
-    @WithMockUser
     void successCustomerSignIn() throws Exception {
         //given
         SignInDto.Response response = new SignInDto.Response();
@@ -78,8 +76,7 @@ class SignInControllerTest {
         //then
         mockMvc.perform(post("/sign-in/customer")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestJson)
-                        .with(csrf()))
+                        .content(requestJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value(0))

--- a/src/test/java/com/zerobase/mytable/controller/SignUpControllerTest.java
+++ b/src/test/java/com/zerobase/mytable/controller/SignUpControllerTest.java
@@ -5,10 +5,10 @@ import com.zerobase.mytable.dto.SignUpDto;
 import com.zerobase.mytable.service.SignUpService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -22,7 +22,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-@WebMvcTest(SignUpController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 class SignUpControllerTest {
 
     @MockBean
@@ -36,7 +37,6 @@ class SignUpControllerTest {
 
     // SingUpDto.Request에 선언된 필드들 유효성 검사 성공 테스트
     @Test
-    @WithMockUser
     void isValidField() throws Exception {
         //given
         SignUpDto.Request request = SignUpDto.Request.builder()
@@ -53,8 +53,7 @@ class SignUpControllerTest {
         //then
         mockMvc.perform(post("/sign-up/partner")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestJson)
-                        .with(csrf()))
+                        .content(requestJson))
                 .andExpect(status().isOk())
                 .andDo(print());
 
@@ -62,7 +61,6 @@ class SignUpControllerTest {
 
     // SingUpDto.Request에 선언된 필드들 유효성 검사 실패 테스트
     @Test
-    @WithMockUser
     void isNotValidField() throws Exception {
         //given
         SignUpDto.Request request = SignUpDto.Request.builder()
@@ -88,7 +86,6 @@ class SignUpControllerTest {
 
     // 파트너 회원가입 성공 테스트
     @Test
-    @WithMockUser
     void successPartnerSignUp() throws Exception {
         //given
         SignUpDto.Response response = new SignUpDto.Response();
@@ -111,8 +108,7 @@ class SignUpControllerTest {
         //then
         mockMvc.perform(post("/sign-up/partner")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestJson)
-                        .with(csrf()))
+                        .content(requestJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value(0))
@@ -122,7 +118,6 @@ class SignUpControllerTest {
 
     // 고객 회원가입 성공 테스트
     @Test
-    @WithMockUser
     void successCustomerSignUp() throws Exception {
         //given
         SignUpDto.Response response = new SignUpDto.Response();
@@ -145,8 +140,7 @@ class SignUpControllerTest {
         //then
         mockMvc.perform(post("/sign-up/customer")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestJson)
-                        .with(csrf()))
+                        .content(requestJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value(0))

--- a/src/test/java/com/zerobase/mytable/service/SignInServiceTest.java
+++ b/src/test/java/com/zerobase/mytable/service/SignInServiceTest.java
@@ -46,7 +46,7 @@ class SignInServiceTest {
                 .thenReturn(Optional.ofNullable(Partner.builder()
                         .uid("abc")
                         .password("123abc!@#")
-                        .roles(Collections.singletonList(UserType.PARTNER.toString()))
+                        .roles(Collections.singletonList(UserType.ROLE_PARTNER.toString()))
                         .build()));
         Mockito.when(passwordEncoder.matches(anyString(), anyString()))
                 .thenReturn(true);
@@ -90,7 +90,7 @@ class SignInServiceTest {
                 .thenReturn(Optional.ofNullable(Partner.builder()
                         .uid("abc")
                         .password("123abc!@#")
-                        .roles(Collections.singletonList(UserType.PARTNER.toString()))
+                        .roles(Collections.singletonList(UserType.ROLE_PARTNER.toString()))
                         .build()));
         Mockito.when(passwordEncoder.matches(anyString(), anyString()))
                 .thenReturn(false);
@@ -113,7 +113,7 @@ class SignInServiceTest {
                 .thenReturn(Optional.ofNullable(Customer.builder()
                         .uid("abc")
                         .password("123abc!@#")
-                        .roles(Collections.singletonList(UserType.CUSTOMER.toString()))
+                        .roles(Collections.singletonList(UserType.ROLE_CUSTOMER.toString()))
                         .build()));
         Mockito.when(passwordEncoder.matches(anyString(), anyString()))
                 .thenReturn(true);
@@ -157,7 +157,7 @@ class SignInServiceTest {
                 .thenReturn(Optional.ofNullable(Customer.builder()
                         .uid("abc")
                         .password("123abc!@#")
-                        .roles(Collections.singletonList(UserType.CUSTOMER.toString()))
+                        .roles(Collections.singletonList(UserType.ROLE_CUSTOMER.toString()))
                         .build()));
         Mockito.when(passwordEncoder.matches(anyString(), anyString()))
                 .thenReturn(false);

--- a/src/test/java/com/zerobase/mytable/service/StoreServiceTest.java
+++ b/src/test/java/com/zerobase/mytable/service/StoreServiceTest.java
@@ -1,0 +1,336 @@
+package com.zerobase.mytable.service;
+
+import com.zerobase.mytable.domain.Partner;
+import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.dto.StoreDto;
+import com.zerobase.mytable.dto.StoreRegisterDto;
+import com.zerobase.mytable.exception.CustomException;
+import com.zerobase.mytable.repository.PartnerRepository;
+import com.zerobase.mytable.repository.StoreRepository;
+import com.zerobase.mytable.security.TokenProvider;
+import com.zerobase.mytable.type.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private PartnerRepository partnerRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    // 점포 등록 성공 테스트
+    @Test
+    void successRegister() {
+        //given
+        Partner partner = Partner.builder().build();
+        Store store = Store.builder().storename("포장마차").build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.empty());
+        given(partnerRepository.getByUid(anyString()))
+                .willReturn(partner);
+        given(tokenProvider.getUid(anyString())).willReturn("abc");
+        given(storeRepository.save(any(Store.class))).willReturn(store);
+
+        //when
+        StoreRegisterDto.Request request = StoreRegisterDto.Request.builder()
+                .storename("포장마차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+
+        StoreRegisterDto.Response response = storeService.register("abc", request);
+
+        //then
+        assertTrue(response.isSuccess());
+        assertEquals(response.getCode(), 0);
+        assertEquals(response.getMsg(), "요청 성공");
+    }
+
+    // 기가입된 점포 등록 테스트
+    @Test
+    void register_AlreadyRegisteredStorename() {
+        //given
+        Store store = Store.builder().storename("포장마차").build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        //when
+        StoreRegisterDto.Request request = StoreRegisterDto.Request.builder()
+                .storename("포장마차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.register("abc", request));
+        //then
+        assertEquals(customException.getErrorCode(),
+                ErrorCode.ALREADY_REGISTERED_STORENAME);
+    }
+
+    // 점포 검색어 자동완성 성공
+    @Test
+    void successAutoComplete() {
+        //given
+        Store store1 = Store.builder().storename("포장마차").build();
+        Store store2 = Store.builder().storename("포장마차 2호점").build();
+        Store store3 = Store.builder().storename("포장마차 3호점").build();
+
+        given(storeRepository.findByStorenameContains(anyString(), any(Pageable.class)))
+                .willReturn(List.of(store1, store2, store3));
+        //when
+        List<String> response = storeService.autoComplete("장");
+        //then
+        assertEquals(response.get(0), "포장마차");
+        assertEquals(response.get(1), "포장마차 2호점");
+        assertEquals(response.get(2), "포장마차 3호점");
+    }
+
+    // 점포 조회 성공
+    @Test
+    void successGetStoreInfo() {
+        //given
+        Store store = Store.builder()
+                .storename("포장마차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        //when
+        StoreDto response = storeService.getStoreInfo("포장마차");
+        //then
+        assertEquals(response.getStorename(), "포장마차");
+        assertEquals(response.getPhone(), "02-111-1111");
+        assertEquals(response.getSido(), "경기도");
+        assertEquals(response.getSigungu(), "군포시");
+        assertEquals(response.getRoadname(), "번영로");
+        assertEquals(response.getDetailAddress(), "행복한 곳");
+        assertEquals(response.getDescription(), "맛있는 가게");
+    }
+
+    // 점포 조회 시 찾으려는 점포 없으면 예외 발생 테스트
+    @Test
+    void getStoreInfo_NotFoundStore() {
+        //given
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.getStoreInfo("abc"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_STORE);
+    }
+
+    // 점포 정보 수정 성공
+    @Test
+    void successUpdateStoreInfo() {
+        //given
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(Partner.builder().uid("abc").build())
+                .build();
+
+        given(storeRepository.findByStorename("aaa"))
+                .willReturn(Optional.of(store));
+        given(storeRepository.findByStorename("포차"))
+                .willReturn(Optional.empty());
+        given(tokenProvider.getUid(anyString())).willReturn("abc");
+        given(storeRepository.save(any(Store.class)))
+                .willReturn(store);
+        //when
+        StoreRegisterDto.Request request = StoreRegisterDto.Request.builder()
+                .storename("포차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+        StoreDto storeDto = storeService.updateStoreInfo("aaa", "aaa", request);
+
+        //then
+        assertEquals(storeDto.getStorename(), "포차");
+        assertEquals(storeDto.getPhone(), "02-111-1111");
+        assertEquals(storeDto.getSido(), "경기도");
+        assertEquals(storeDto.getSigungu(), "군포시");
+        assertEquals(storeDto.getRoadname(), "번영로");
+        assertEquals(storeDto.getDetailAddress(), "행복한 곳");
+        assertEquals(storeDto.getDescription(), "맛있는 가게");
+    }
+
+    // 점포 수정 시 등록되지 않은 점포인 경우 예외 처리 테스트
+    @Test
+    void updateStoreInfo_NotFoundStore() {
+        //given
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        StoreRegisterDto.Request request = StoreRegisterDto.Request.builder()
+                .storename("포차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.updateStoreInfo("abc", "abc", request));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_STORE);
+    }
+
+    // 점포 수정 시 점포 등록한 파트너가 아닌 경우 예외 처리
+    @Test
+    void updateStoreInfo_AccessDenied() {
+        //given
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(Partner.builder().uid("abcd").build())
+                .build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString())).willReturn("jjj");
+        //when
+        StoreRegisterDto.Request request = StoreRegisterDto.Request.builder()
+                .storename("포차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.updateStoreInfo("abc", "abc", request));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_DENIED);
+    }
+
+    // 점포 수정 시 수정하려는 점포명이 이미 등록되어 있을 경우 예외 처리
+    @Test
+    void updateStoreInfo_AlreadyRegisteredStorename() {
+        //given
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(Partner.builder().uid("abc").build())
+                .build();
+
+        given(storeRepository.findByStorename("포장마차"))
+                .willReturn(Optional.of(store));
+        given(storeRepository.findByStorename("포차"))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString())).willReturn("abc");
+
+        //when
+        StoreRegisterDto.Request request = StoreRegisterDto.Request.builder()
+                .storename("포차")
+                .phone("02-111-1111")
+                .sido("경기도")
+                .sigungu("군포시")
+                .roadname("번영로")
+                .detailAddress("행복한 곳")
+                .description("맛있는 가게")
+                .build();
+
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.updateStoreInfo("abc", "포장마차", request));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ALREADY_REGISTERED_STORENAME);
+    }
+
+    // 점포 삭제 성공
+    @Test
+    void successDeleteStore() {
+        //given
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(Partner.builder().uid("abc").build())
+                .build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString())).willReturn("abc");
+
+        //when
+        StoreRegisterDto.Response response = storeService.deleteStore("abc", "포장마차");
+
+        //then
+        assertTrue(response.isSuccess());
+        assertEquals(response.getCode(), 0);
+        assertEquals(response.getMsg(), "요청 성공");
+    }
+
+    // 점포 삭제 시 요청한 점포명이 등록되어 있지 않을 경우 예외 처리
+    @Test
+    void deleteStore_NotFoundStore() {
+        //given
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.deleteStore("abc", "포장마차"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_STORE);
+    }
+
+    // 삭제 요청한 점포를 등록한 파트너가 아닌 다른 파트너가 삭제 요청할 경우 예외 처리
+    @Test
+    void deleteStore_AccessDenied() {
+        //given
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(Partner.builder().uid("abcd").build())
+                .build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString())).willReturn("jjj");
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.deleteStore("abc", "abc"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_DENIED);
+    }
+
+}


### PR DESCRIPTION
Changes
---
1. 점포 등록 구현(파트너만 가능)
2. 점포 검색어 자동완성 구현
3. 점포정보 조회 구현
4. 점포정보 수정 구현
5. 점포정보 삭제 구현
6. 점포등록, 조회, 수정, 삭제 시 시나리오 별 예외 처리 테스트 코드 작성 및 확인

기존 코드 수정사항
---
1. jwt Filter로 인해 접근 제한될 경우 CustomeAccessDeniedHandler를 통해 다른 페이지로 리다이렉트 --> ACCESS_DENIED 에러 리스폰스 반환으로 변경
- 변경사유 : 다른 페이지 리다이렉트보다 개발단계에서는 명시적으로 예외처리 하는 것이 바람직하다고 판단
2. TokenProvider클래스의 getAuthentication() 메서드가 userdetails 정보를 가져올 때 partner 정보만 가져올 수 있었음. --> partner, customer 구별하여 정보 가져올 수 있도록 처리

