### PR TITLE
[003-STORE] 예약 관련 서비스 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+application-api-key.properties
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,13 @@ dependencies {
     // 필드 유효성 검사를 위한 라이브러리
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 고객이 예약 요청 시 점주에게 문자 전송
+    implementation 'net.nurigo:sdk:4.3.0'
+
+    // 스웨거 적용
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // 컨트롤러 테스트 시 csrf관련 에러 처리를 위한 의존성 주입

--- a/src/main/java/com/zerobase/mytable/MytableApplication.java
+++ b/src/main/java/com/zerobase/mytable/MytableApplication.java
@@ -2,8 +2,10 @@ package com.zerobase.mytable;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MytableApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/zerobase/mytable/config/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/mytable/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.zerobase.mytable.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build().apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("매장 예약 서비스")
+                .description("매장 사용 예약 서비스를 제공하는 api")
+                .version("1.0")
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/mytable/controller/CustomerController.java
+++ b/src/main/java/com/zerobase/mytable/controller/CustomerController.java
@@ -1,0 +1,63 @@
+package com.zerobase.mytable.controller;
+
+import com.zerobase.mytable.dto.ReservationDto;
+import com.zerobase.mytable.service.ReservationService;
+import com.zerobase.mytable.type.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/customer/reservation")
+@PreAuthorize("hasRole('CUSTOMER')")
+public class CustomerController {
+
+    private final ReservationService reservationService;
+
+    // 예약 요청
+    @PostMapping("/request")
+    public CommonResponse makeReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @Valid @RequestBody ReservationDto request) {
+        return reservationService.makeReservation(token, request);
+    }
+
+    // 고객이 예약한 목록 조회
+    @GetMapping("/my-list")
+    public Page<ReservationDto> getMyReservations(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam Integer page, @RequestParam Integer size) {
+        return reservationService.customerGetMyReservations(token,
+                PageRequest.of(page, size));
+    }
+
+    // 예약 상세 정보 조회
+    @GetMapping("/detail")
+    public ReservationDto getReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid) {
+        return reservationService.customerGetReservation(token, reservationUid);
+    }
+
+    // 예약 정보 수정
+    @PutMapping("/detail/update")
+    public ReservationDto updateReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid,
+            @Valid @RequestBody ReservationDto request) {
+        return reservationService.updateReservation(token, reservationUid, request);
+    }
+
+    // 예약 취소
+    @PostMapping("/detail/cancel")
+    public ReservationDto cancelReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid) {
+        return reservationService.cancelReservation(token, reservationUid);
+    }
+}

--- a/src/main/java/com/zerobase/mytable/controller/PartnerController.java
+++ b/src/main/java/com/zerobase/mytable/controller/PartnerController.java
@@ -1,0 +1,95 @@
+package com.zerobase.mytable.controller;
+
+import com.zerobase.mytable.dto.ReservationDto;
+import com.zerobase.mytable.dto.StoreDto;
+import com.zerobase.mytable.service.ReservationService;
+import com.zerobase.mytable.service.StoreService;
+import com.zerobase.mytable.type.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/partner")
+@PreAuthorize("hasRole('PARTNER')")
+public class PartnerController {
+
+    private final ReservationService reservationService;
+    private final StoreService storeService;
+
+    // 예약 상세정보 조회
+    @GetMapping("/reservation/detail")
+    public ReservationDto partnerGetReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid) {
+        return reservationService.partnerGetReservation(token, reservationUid);
+    }
+
+    // 예약 승인
+    @PostMapping("/reservation/detail/confirm")
+    public ReservationDto confirmReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid) {
+        return reservationService.partnerReservationConfirm(token, reservationUid);
+    }
+
+    // 예약 거절
+    @PostMapping("/reservation/detail/reject")
+    public ReservationDto rejectReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid) {
+        return reservationService.partnerReservationReject(token, reservationUid);
+    }
+
+    // 파트너가 관리하고 있는 점포 목록 조회
+    @GetMapping("/my-stores")
+    public Page<StoreDto> getMyStores(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam Integer page, @RequestParam Integer size) {
+        return storeService.getMyStores(token, PageRequest.of(page, size));
+    }
+
+    // 파트너가 관리하고 있는 점포의 예약 목록 조회
+    @GetMapping("/store/reservations")
+    @PreAuthorize("hasRole('PARTNER')")
+    public Page<ReservationDto> getReservationsByStore(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String storename,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                LocalDate endDate,
+            @RequestParam Integer page, @RequestParam Integer size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        return storeService.getReservationsByStore(token, storename,
+                startDate, endDate, pageRequest);
+    }
+
+    // 키오스크에서 예약 검색
+    @GetMapping("/store/reservation/search")
+    @PreAuthorize("hasRole('PARTNER')")
+    public Page<ReservationDto> searchReservation(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String storename, @RequestParam String underName,
+            @RequestParam String phone,
+            @RequestParam Integer page, @RequestParam Integer size) {
+        return storeService.searchReservation(
+                token, storename, underName, phone, PageRequest.of(page, size));
+    }
+
+    // 키오스크에서 예약 도착 확인
+    @PostMapping("/reservation/arrival-check")
+    @PreAuthorize("hasRole('PARTNER')")
+    public CommonResponse arrivalConfirm(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam String reservationUid) {
+        return storeService.arrivalConfirm(token, reservationUid);
+    }
+
+}

--- a/src/main/java/com/zerobase/mytable/controller/StoreController.java
+++ b/src/main/java/com/zerobase/mytable/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.zerobase.mytable.controller;
 
+import com.zerobase.mytable.dto.ReservationDto;
 import com.zerobase.mytable.dto.StoreDto;
 import com.zerobase.mytable.dto.StoreRegisterDto;
 import com.zerobase.mytable.service.StoreService;
@@ -8,7 +9,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/zerobase/mytable/domain/BaseEntity.java
+++ b/src/main/java/com/zerobase/mytable/domain/BaseEntity.java
@@ -1,9 +1,6 @@
 package com.zerobase.mytable.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/zerobase/mytable/domain/Customer.java
+++ b/src/main/java/com/zerobase/mytable/domain/Customer.java
@@ -11,10 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Entity
@@ -52,6 +49,9 @@ public class Customer extends BaseEntity implements UserDetails {
     // 사용권한 분류, Collection 형태 저장할 때 쓰는 어노테이션
     @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
     private List<String> roles;
+
+    @OneToMany(mappedBy = "customer", cascade = CascadeType.PERSIST)
+    private List<Reservation> reservations = new ArrayList<>();
 
     // 계정이 가지고 있는 권한 목록을 리턴
     @Override

--- a/src/main/java/com/zerobase/mytable/domain/Partner.java
+++ b/src/main/java/com/zerobase/mytable/domain/Partner.java
@@ -11,10 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Entity
@@ -49,6 +46,9 @@ public class Partner extends BaseEntity implements UserDetails {
 
     @Column(nullable = false)
     private LocalDate birth;
+
+    @OneToMany(mappedBy = "partner", cascade = CascadeType.PERSIST)
+    private List<Store> stores = new ArrayList<>();
 
     // 사용권한 분류, Collection 형태 저장할 때 쓰는 어노테이션
     @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)

--- a/src/main/java/com/zerobase/mytable/domain/Reservation.java
+++ b/src/main/java/com/zerobase/mytable/domain/Reservation.java
@@ -1,0 +1,62 @@
+package com.zerobase.mytable.domain;
+
+import com.zerobase.mytable.dto.ReservationDto;
+import com.zerobase.mytable.type.ReservationStatus;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+public class Reservation extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String uid;
+
+    // 예약 요청 고객
+    @ManyToOne
+    private Customer customer;
+
+    // 예약 날짜
+    private LocalDateTime dateTime;
+
+    // 예약자 이름
+    private String underName;
+
+    // 연락처
+    private String phone;
+
+    // 요청 사항
+    private String specialInstruction;
+
+    // 예약 확정 여부
+    private ReservationStatus status;
+
+    // 예약 점포
+    @ManyToOne
+    private Store store;
+
+    public static Reservation from(ReservationDto request, Customer customer, Store store) {
+        return Reservation.builder()
+                .uid(UUID.randomUUID().toString().replace("-", ""))
+                .customer(customer)
+                .dateTime(LocalDateTime.of(request.getDate(), request.getTime()))
+                .underName(request.getUnderName())
+                .phone(request.getPhone())
+                .specialInstruction(request.getSpecialInstruction())
+                .status(ReservationStatus.WAITING)
+                .store(store)
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/mytable/domain/Store.java
+++ b/src/main/java/com/zerobase/mytable/domain/Store.java
@@ -1,11 +1,13 @@
 package com.zerobase.mytable.domain;
 
 import com.zerobase.mytable.dto.StoreRegisterDto;
+import com.zerobase.mytable.type.Address;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,18 +28,9 @@ public class Store extends BaseEntity{
     @Column
     private String phone;
 
-    // 점포 입력 받을 때 주소 입력(추후 통계 처리할 경우를 위해 시도/ 시군구/ 도로명 / 상세주소로 나눠서 받음)
     @Column(nullable = false)
-    private String sido;
-
-    @Column(nullable = false)
-    private String sigungu;
-
-    @Column(nullable = false)
-    private String roadname;
-
-    @Column(nullable = false)
-    private String detailAddress;
+    @Embedded
+    private Address address;
 
     // 상점에 대한 설명 입력
     @Column(nullable = false)
@@ -46,14 +39,19 @@ public class Store extends BaseEntity{
     @ManyToOne
     private Partner partner;
 
+    @OneToMany(mappedBy = "store", cascade = CascadeType.PERSIST)
+    private List<Reservation> reservations = new ArrayList<>();
+
     public static Store from(StoreRegisterDto.Request request){
         return Store.builder()
                 .storename(request.getStorename())
                 .phone(request.getPhone())
-                .sido(request.getSido())
-                .sigungu(request.getSigungu())
-                .roadname(request.getRoadname())
-                .detailAddress(request.getDetailAddress())
+                .address(Address.builder()
+                        .sido(request.getSido())
+                        .sigungu(request.getSigungu())
+                        .roadname(request.getRoadname())
+                        .detailAddress(request.getDetailAddress())
+                        .build())
                 .description(request.getDescription())
                 .build();
     }

--- a/src/main/java/com/zerobase/mytable/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/zerobase/mytable/domain/restaurant/Restaurant.java
@@ -1,0 +1,18 @@
+package com.zerobase.mytable.domain.restaurant;
+
+import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.type.Table;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import java.util.List;
+
+@Entity
+public class Restaurant extends Store {
+    @ElementCollection(targetClass = Table.class, fetch = FetchType.LAZY)
+    private List<Table> tables;
+
+    // from 메소드 사용할 경우 테이블 정렬해서 입력
+    // request.getTables().sort(Comparator.comparingInt(Table::getTableVolume));
+}

--- a/src/main/java/com/zerobase/mytable/domain/restaurant/RestaurantReservation.java
+++ b/src/main/java/com/zerobase/mytable/domain/restaurant/RestaurantReservation.java
@@ -1,0 +1,17 @@
+package com.zerobase.mytable.domain.restaurant;
+
+import com.zerobase.mytable.domain.Reservation;
+import com.zerobase.mytable.type.Table;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+
+@Entity
+public class RestaurantReservation extends Reservation {
+
+    // 예약 인원
+    private Integer numberOfPeople;
+
+    @Embedded
+    private Table table;
+}

--- a/src/main/java/com/zerobase/mytable/dto/ReservationDto.java
+++ b/src/main/java/com/zerobase/mytable/dto/ReservationDto.java
@@ -1,0 +1,63 @@
+package com.zerobase.mytable.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.zerobase.mytable.domain.Reservation;
+import com.zerobase.mytable.type.ReservationStatus;
+import lombok.*;
+
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+import javax.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReservationDto {
+
+    @Null(message = "null이어야 합니다.")
+    private String uid;
+
+    @NotNull(message = "반드시 값이 있어야 합니다.")
+    @FutureOrPresent(message = "예약일은 오늘 이후여야 합니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd",
+            timezone = "Asia/Seoul")
+    private LocalDate date;
+
+    @NotNull(message = "반드시 값이 있어야 합니다.")
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime time;
+
+    @NotNull(message = "반드시 값이 있어야 합니다.")
+    private String underName;
+
+    @NotNull(message = "반드시 값이 있어야 합니다.")
+    @Pattern(regexp = "^01([0|1|6|7|8|9]?)-?([0-9]{3,4})-?([0-9]{4})$")
+    private String phone;
+
+    private String specialInstruction;
+
+    @NotNull(message = "반드시 값이 있어야 합니다.")
+    private String storename;
+
+    @Null(message = "null이어야 합니다.")
+    private ReservationStatus status;
+
+    public static ReservationDto from(Reservation reservation){
+        return ReservationDto.builder()
+                .uid(reservation.getUid())
+                .date(reservation.getDateTime().toLocalDate())
+                .time(reservation.getDateTime().toLocalTime())
+                .underName(reservation.getUnderName())
+                .phone(reservation.getPhone())
+                .specialInstruction(reservation.getSpecialInstruction())
+                .storename(reservation.getStore().getStorename())
+                .status(reservation.getStatus())
+                .build();
+    }
+
+}

--- a/src/main/java/com/zerobase/mytable/dto/StoreDto.java
+++ b/src/main/java/com/zerobase/mytable/dto/StoreDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.mytable.dto;
 
 import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.type.Address;
 import lombok.*;
 
 @Getter
@@ -14,24 +15,15 @@ public class StoreDto {
 
     private String phone;
 
-    private String sido;
-
-    private String sigungu;
-
-    private String roadname;
-
-    private String detailAddress;
+    private Address address;
 
     private String description;
 
-    public static StoreDto from(Store store){
+    public static StoreDto from(Store store) {
         return StoreDto.builder()
                 .storename(store.getStorename())
                 .phone(store.getPhone())
-                .sido(store.getSido())
-                .sigungu(store.getSigungu())
-                .roadname(store.getRoadname())
-                .detailAddress(store.getDetailAddress())
+                .address(store.getAddress())
                 .description(store.getDescription())
                 .build();
     }

--- a/src/main/java/com/zerobase/mytable/dto/StoreRegisterDto.java
+++ b/src/main/java/com/zerobase/mytable/dto/StoreRegisterDto.java
@@ -34,6 +34,7 @@ public class StoreRegisterDto {
 
         @NotNull(message = "반드시 값이 있어야 합니다.")
         private String description;
+
     }
 
     @Getter

--- a/src/main/java/com/zerobase/mytable/dto/restaurant/RestaurantReservationDto.java
+++ b/src/main/java/com/zerobase/mytable/dto/restaurant/RestaurantReservationDto.java
@@ -1,0 +1,19 @@
+package com.zerobase.mytable.dto.restaurant;
+
+import com.zerobase.mytable.dto.ReservationDto;
+import lombok.*;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RestaurantReservationDto extends ReservationDto {
+
+    @NotNull(message = "반드시 값이 있어야 합니다.")
+    @Min(value = 1, message = "예약 가능 인원은 1명 이상부터 입니다.")
+    private Integer numberOfPeople;
+
+}

--- a/src/main/java/com/zerobase/mytable/repository/ReservationRepository.java
+++ b/src/main/java/com/zerobase/mytable/repository/ReservationRepository.java
@@ -1,0 +1,20 @@
+package com.zerobase.mytable.repository;
+
+import com.zerobase.mytable.domain.Reservation;
+import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.type.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Optional<Reservation> findByUid(String uid);
+    List<Reservation> findAllByUnderNameAndPhoneAndStoreAndStatus(
+            String underName, String phone, Store store, ReservationStatus status);
+    List<Reservation> findAllByStatusAndDateTimeBefore(
+            ReservationStatus reservationStatus, LocalDateTime dateTime);
+}

--- a/src/main/java/com/zerobase/mytable/service/CustomerService.java
+++ b/src/main/java/com/zerobase/mytable/service/CustomerService.java
@@ -13,7 +13,6 @@ public class CustomerService implements UserDetailsService {
 
     private final CustomerRepository customerRepository;
 
-
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return customerRepository.getByUid(username);

--- a/src/main/java/com/zerobase/mytable/service/PartnerService.java
+++ b/src/main/java/com/zerobase/mytable/service/PartnerService.java
@@ -1,7 +1,6 @@
 package com.zerobase.mytable.service;
 
 import com.zerobase.mytable.repository.PartnerRepository;
-import com.zerobase.mytable.type.UserType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/zerobase/mytable/service/ReservationService.java
+++ b/src/main/java/com/zerobase/mytable/service/ReservationService.java
@@ -1,0 +1,238 @@
+package com.zerobase.mytable.service;
+
+import com.zerobase.mytable.domain.Customer;
+import com.zerobase.mytable.domain.Reservation;
+import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.dto.ReservationDto;
+import com.zerobase.mytable.exception.CustomException;
+import com.zerobase.mytable.repository.CustomerRepository;
+import com.zerobase.mytable.repository.ReservationRepository;
+import com.zerobase.mytable.repository.StoreRepository;
+import com.zerobase.mytable.security.TokenProvider;
+import com.zerobase.mytable.type.CommonResponse;
+import com.zerobase.mytable.type.ErrorCode;
+import com.zerobase.mytable.type.ReservationStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final StoreRepository storeRepository;
+    private final CustomerRepository customerRepository;
+    private final TokenProvider tokenProvider;
+    private final SendMessageService sendMessageService;
+
+    // 예약 요청
+    @Transactional
+    public CommonResponse makeReservation(String token, ReservationDto request) {
+        Store store = storeRepository.findByStorename(request.getStorename())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_STORE));
+
+        if (!LocalDate.now().plusMonths(1).isAfter(request.getDate())) {
+            throw new CustomException(ErrorCode.RESERVATION_DATE_MUST_BE_IN_A_MONTH);
+        }
+
+        Customer customer = customerRepository.getByUid(tokenProvider.getUid(token));
+        Reservation savedReservation = reservationRepository.save(
+                Reservation.from(request, customer, store));
+
+        if (!savedReservation.getUnderName().isEmpty()) {
+            sendReservationMessageToPartner(savedReservation);
+            return CommonResponse.SUCCESS;
+        } else {
+            return CommonResponse.FAIL;
+        }
+    }
+
+    // 고객이 예약한 예약 리스트 조회
+    public Page<ReservationDto> customerGetMyReservations(
+            String token, PageRequest pageRequest) {
+        Customer customer = customerRepository.getByUid(tokenProvider.getUid(token));
+
+        List<ReservationDto> reservationDtos =
+                customer.getReservations().stream()
+                        .sorted(Comparator.comparing(Reservation::getDateTime))
+                        .map(ReservationDto::from)
+                        .collect(Collectors.toList());
+
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), reservationDtos.size());
+
+        return new PageImpl<>(
+                reservationDtos.subList(start, end),
+                pageRequest,
+                reservationDtos.size());
+    }
+
+    // 고객 예약 상세정보 조회
+    public ReservationDto customerGetReservation(String token, String reservationUid) {
+
+        Reservation reservation = getReservationAndValidateCustomer(
+                token, reservationUid);
+
+        return ReservationDto.from(reservation);
+    }
+
+    // 고객 예약 수정
+    public ReservationDto updateReservation(String token, String reservationUid,
+                                            ReservationDto request) {
+        Reservation reservation = getReservationAndValidateCustomer(
+                token, reservationUid);
+
+        if (!reservation.getStore().getStorename().equals(request.getStorename())) {
+            throw new CustomException(ErrorCode.CANNOT_UPDATE_STORE);
+        }
+
+        reservation.setDateTime(LocalDateTime.of(request.getDate(), request.getTime()));
+        reservation.setUnderName(request.getUnderName());
+        reservation.setPhone(request.getPhone());
+        reservation.setSpecialInstruction(request.getSpecialInstruction());
+        reservation.setStatus(ReservationStatus.WAITING);
+
+        Reservation savedReservation = reservationRepository.save(reservation);
+        sendReservationMessageToPartner(savedReservation);
+
+        return ReservationDto.from(savedReservation);
+    }
+
+    // 고객 예약 취소
+    public ReservationDto cancelReservation(String token, String reservationUid) {
+        Reservation reservation = getReservationAndValidateCustomer(
+                token, reservationUid);
+
+        reservation.setStatus(ReservationStatus.CANCEL);
+
+        return ReservationDto.from(reservationRepository.save(reservation));
+    }
+
+    // 파트너 예약 상세정보 조회
+    public ReservationDto partnerGetReservation(String token, String reservationUid) {
+        Reservation reservation = getReservationAndValidatePartner(
+                token, reservationUid);
+
+        return ReservationDto.from(reservation);
+    }
+
+    // 파트너 예약 승인
+    public ReservationDto partnerReservationConfirm(String token, String reservationUid) {
+        Reservation reservation = getReservationAndValidatePartner(
+                token, reservationUid);
+
+        reservation.setStatus(ReservationStatus.CONFIRM);
+        Reservation savedReservation = reservationRepository.save(reservation);
+
+        sendReservationMessageToCustomer(savedReservation);
+
+        return ReservationDto.from(savedReservation);
+    }
+
+
+    // 파트너 예약 거절
+    public ReservationDto partnerReservationReject(String token, String reservationUid) {
+        Reservation reservation = getReservationAndValidatePartner(
+                token, reservationUid);
+
+        reservation.setStatus(ReservationStatus.DENIED);
+        Reservation savedReservation = reservationRepository.save(reservation);
+
+        sendReservationMessageToCustomer(savedReservation);
+
+        return ReservationDto.from(savedReservation);
+    }
+
+    // 매일 00시 05분에 예약 상태 confirm인 건(도착확인 안 된 건)들 NO_SHOW로 변경
+    @Transactional
+    @Scheduled(cron = "${schedules.cron.check.no-show}")
+    public void checkReservationNoShow() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<Reservation> reservations =
+                reservationRepository.findAllByStatusAndDateTimeBefore(
+                        ReservationStatus.CONFIRM, yesterday.atTime(LocalTime.MAX));
+
+        for (Reservation reservation : reservations) {
+            reservation.setStatus(ReservationStatus.NO_SHOW);
+            reservationRepository.save(reservation);
+        }
+    }
+
+    private Reservation getReservation(String reservationUid) {
+        return reservationRepository.findByUid(reservationUid)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+    }
+
+
+    // 예약 요청 문자 발송 메서드
+    private void sendReservationMessageToPartner(Reservation reservation) {
+        String text = String.format("%s에 예약이 접수(수정)되었습니다.\n" +
+                        "- 예약일자 : %s\n" +
+                        "- 예약자명 : %s\n" +
+                        "예약 상세내용 바로가기\n" +
+                        "> http://localhost:8080/partner/reservation/detail?uid=%s",
+                reservation.getStore().getStorename(),
+                reservation.getDateTime().format(
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                reservation.getUnderName(),
+                reservation.getUid());
+
+        sendMessageService.sendOneMessage(
+                reservation.getStore().getPartner().getPhone(),
+                text);
+    }
+
+    // 예약 확정 및 거절 문자 발송 메서드
+    private void sendReservationMessageToCustomer(Reservation reservation) {
+        String text = String.format("%s에 예약이 %s되었습니다.\n" +
+                        "- 예약일자 : %s\n" +
+                        "- 예약자명 : %s\n" +
+                        "예약 상세내용 바로가기\n" +
+                        "> http://localhost:8080/customer/reservation/detail?uid=%s",
+                reservation.getStatus().getMsg(),
+                reservation.getStore().getStorename(),
+                reservation.getDateTime().format(
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                reservation.getUnderName(),
+                reservation.getUid());
+
+        sendMessageService.sendOneMessage(reservation.getPhone(), text);
+    }
+
+    private Reservation getReservationAndValidateCustomer(String token, String reservationUid) {
+        Reservation reservation = getReservation(reservationUid);
+
+        if (!reservation.getCustomer().getUid().equals(tokenProvider.getUid(token))) {
+            throw new CustomException(ErrorCode.ACCESS_ONLY_REQUESTED_CUSTOMER);
+        }
+
+        return reservation;
+    }
+
+    private Reservation getReservationAndValidatePartner(String token, String reservationUid) {
+        Reservation reservation = getReservation(reservationUid);
+
+        if (!reservation.getStore().getPartner().getUid().equals(
+                tokenProvider.getUid(token))) {
+            throw new CustomException(ErrorCode.ACCESS_ONLY_STORE_OWNER);
+        }
+
+        return reservation;
+    }
+
+}

--- a/src/main/java/com/zerobase/mytable/service/SendMessageService.java
+++ b/src/main/java/com/zerobase/mytable/service/SendMessageService.java
@@ -1,0 +1,39 @@
+package com.zerobase.mytable.service;
+
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class SendMessageService {
+    // 메세지 전송 서비스를 위한 api_key, api_secrte 지정
+    @Value(value = "${api.key}")
+    private String apiKey;
+    @Value(value = "${api.secret}")
+    private String apiSecret;
+
+    // 발신번호 따로 관리
+    @Value(value = "${caller.number}")
+    private String callerNumber;
+
+
+    public SingleMessageSentResponse sendOneMessage(String phone, String text) {
+
+        DefaultMessageService messageService = NurigoApp.INSTANCE.initialize(apiKey,
+                apiSecret, "https://api.coolsms.co.kr");
+
+        Message message = new Message();
+
+        message.setFrom(callerNumber);
+        message.setTo(phone.replace("-", ""));
+        message.setText(text);
+
+        return messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+}

--- a/src/main/java/com/zerobase/mytable/service/StoreService.java
+++ b/src/main/java/com/zerobase/mytable/service/StoreService.java
@@ -1,20 +1,33 @@
 package com.zerobase.mytable.service;
 
+import com.zerobase.mytable.domain.BaseEntity;
+import com.zerobase.mytable.domain.Partner;
+import com.zerobase.mytable.domain.Reservation;
 import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.dto.ReservationDto;
 import com.zerobase.mytable.dto.StoreDto;
 import com.zerobase.mytable.dto.StoreRegisterDto;
 import com.zerobase.mytable.exception.CustomException;
 import com.zerobase.mytable.repository.PartnerRepository;
+import com.zerobase.mytable.repository.ReservationRepository;
 import com.zerobase.mytable.repository.StoreRepository;
 import com.zerobase.mytable.security.TokenProvider;
+import com.zerobase.mytable.type.Address;
+import com.zerobase.mytable.type.CommonResponse;
 import com.zerobase.mytable.type.ErrorCode;
+import com.zerobase.mytable.type.ReservationStatus;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,9 +35,10 @@ import java.util.stream.Collectors;
 @Slf4j
 public class StoreService {
 
-    private StoreRepository storeRepository;
-    private PartnerRepository partnerRepository;
-    private TokenProvider tokenProvider;
+    private final StoreRepository storeRepository;
+    private final PartnerRepository partnerRepository;
+    private final ReservationRepository reservationRepository;
+    private final TokenProvider tokenProvider;
 
     // 점포 등록
     public StoreRegisterDto.Response register(String token, StoreRegisterDto.Request request) {
@@ -39,7 +53,7 @@ public class StoreService {
 
         StoreRegisterDto.Response response = new StoreRegisterDto.Response();
 
-        if (!savedStore.getStorename().isEmpty()){
+        if (!savedStore.getStorename().isEmpty()) {
             setSuccessResult(response);
         } else {
             setFailResult(response);
@@ -69,16 +83,19 @@ public class StoreService {
 
         partnerValidate(token, store);
 
-        if (storeRepository.findByStorename(updateRequest.getStorename()).isPresent()) {
+        if (storeRepository.findByStorename(updateRequest.getStorename()).isPresent()
+                && !updateRequest.getStorename().equals(existingStorename)) {
             throw new CustomException(ErrorCode.ALREADY_REGISTERED_STORENAME);
         }
 
         store.setStorename(updateRequest.getStorename());
         store.setPhone(updateRequest.getPhone());
-        store.setSido(updateRequest.getSido());
-        store.setSigungu(updateRequest.getSigungu());
-        store.setRoadname(updateRequest.getRoadname());
-        store.setDetailAddress(updateRequest.getDetailAddress());
+        store.setAddress(Address.builder()
+                .sido(updateRequest.getSido())
+                .sigungu(updateRequest.getSigungu())
+                .roadname(updateRequest.getRoadname())
+                .detailAddress(updateRequest.getDetailAddress())
+                .build());
         store.setDescription(updateRequest.getDescription());
 
         return StoreDto.from(storeRepository.save(store));
@@ -98,6 +115,126 @@ public class StoreService {
         return response;
     }
 
+    // 파트너에 해당하는 점포 리스트 조회
+    public Page<StoreDto> getMyStores(String token, PageRequest pageRequest) {
+        Partner partner = partnerRepository.getByUid(tokenProvider.getUid(token));
+
+        List<StoreDto> storeDtos = partner.getStores().stream()
+                .sorted(Comparator.comparing(BaseEntity::getCreatedAt))
+                .map(StoreDto::from)
+                .collect(Collectors.toList());
+
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), storeDtos.size());
+
+        return new PageImpl<>(
+                storeDtos.subList(start, end),
+                pageRequest,
+                storeDtos.size());
+    }
+
+    // 파트너 점포 별 예약 조회
+    // 1. 현재 시간 이후의 예약 목록만 줄 것
+    // 2. 예약 시간 별 구분해서 반환할 것
+    public Page<ReservationDto> getReservationsByStore(
+            String token,
+            String storename,
+            LocalDate startDate,
+            LocalDate endDate,
+            PageRequest pageRequest) {
+        Store store = storeRepository.findByStorename(storename)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_STORE));
+
+        partnerValidate(token, store);
+
+        // 1. reservation의 날짜로 필터링
+        // 2. reservation 예약 일자 별로 오름차순 정렬
+        // 3. reservation 예약 일자 같을 경우 생성 시간 별로 오름차순 정렬
+        List<ReservationDto> reservationDtos = store.getReservations().stream()
+                .filter(x -> x.getDateTime().isAfter(startDate.atStartOfDay())
+                        && x.getDateTime().isBefore(endDate.atTime(LocalTime.MAX)))
+                .sorted((x, y) -> {
+                    if (x.getDateTime().isBefore(y.getDateTime())) {
+                        return -1;
+                    } else if (x.getDateTime().isEqual(y.getDateTime())) {
+                        if (x.getCreatedAt().isBefore(y.getCreatedAt())) {
+                            return -1;
+                        } else if (x.getCreatedAt().isEqual(y.getCreatedAt())) {
+                            return 0;
+                        } else {
+                            return 1;
+                        }
+                    } else {
+                        return 1;
+                    }
+                })
+                .map(ReservationDto::from)
+                .collect(Collectors.toList());
+
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), reservationDtos.size());
+
+        return new PageImpl<>(
+                reservationDtos.subList(start, end),
+                pageRequest,
+                reservationDtos.size());
+    }
+
+    // 파트너 키오스크에서 예약자명과 전화번호를 통해 예약 검색
+    public Page<ReservationDto> searchReservation(String token,
+                                            String storename,
+                                            String underName,
+                                            String phone,
+                                            PageRequest pageRequest) {
+        Store store = storeRepository.findByStorename(storename)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_STORE));
+
+        // 점포의 파트너와 키오스크에 접속한 파트너가 다른 경우 예외 처리
+        partnerValidate(token, store);
+
+        List<ReservationDto> reservationDtos =
+                reservationRepository.findAllByUnderNameAndPhoneAndStoreAndStatus(
+                        underName, phone, store, ReservationStatus.CONFIRM).stream()
+                        .sorted(Comparator.comparing(Reservation::getDateTime))
+                        .map(ReservationDto::from)
+                        .collect(Collectors.toList());
+
+        if (reservationDtos.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_RESERVATION);
+        }
+
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), reservationDtos.size());
+
+        return new PageImpl<>(
+                reservationDtos.subList(start, end),
+                pageRequest,
+                reservationDtos.size());
+    }
+
+    // 파트너 키오스크에서 예약 도착 확인
+    public CommonResponse arrivalConfirm(String token, String reservationUid) {
+        Reservation reservation = reservationRepository.findByUid(reservationUid)
+                .orElseThrow(() ->
+                        new CustomException(ErrorCode.NOT_FOUND_RESERVATION));
+
+        partnerValidate(token, reservation.getStore());
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(reservation.getDateTime().minusMinutes(10L))) {
+            throw new CustomException(ErrorCode.ENTRANCE_NOT_ON_TIME);
+        } else if (now.isAfter(reservation.getDateTime().plusMinutes(10L))) {
+            throw new CustomException(ErrorCode.TIME_OVER);
+        }
+
+        reservation.setStatus(ReservationStatus.ARRIVED);
+        reservationRepository.save(reservation);
+
+        return CommonResponse.SUCCESS;
+    }
+
+
     private Store getStore(String storename) {
         return storeRepository.findByStorename(storename)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_STORE));
@@ -116,7 +253,7 @@ public class StoreService {
         response.setMsg("요청 실패");
     }
 
-    private void partnerValidate(String token, Store store){
+    private void partnerValidate(String token, Store store) {
         if (!store.getPartner().getUid().equals(tokenProvider.getUid(token))) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }

--- a/src/main/java/com/zerobase/mytable/type/Address.java
+++ b/src/main/java/com/zerobase/mytable/type/Address.java
@@ -1,0 +1,18 @@
+package com.zerobase.mytable.type;
+
+import lombok.*;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Address {
+    private String sido;
+    private String sigungu;
+    private String roadname;
+    private String detailAddress;
+}

--- a/src/main/java/com/zerobase/mytable/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/mytable/type/ErrorCode.java
@@ -17,7 +17,19 @@ public enum ErrorCode {
 
     // 점포 등록 관련
     ALREADY_REGISTERED_STORENAME("이미 존재하는 점포명입니다."),
-    NOT_FOUND_STORE("존재하지 않는 점포입니다.");
+    NOT_FOUND_STORE("존재하지 않는 점포입니다."),
+
+    // 예약 관련
+    RESERVATION_DATE_MUST_BE_IN_A_MONTH("예약은 한달 이내만 가능합니다."),
+    TOO_MANY_NUMBER_OF_PEOPLE("예약인원을 수용할 테이블이 없습니다. 점포로 문의해주세요."),
+    RESERVATION_NOT_FOUND("해당 예약을 찾을 수 없습니다."),
+    CANNOT_UPDATE_STORE("점포를 수정할 수 없습니다. 해당 점포로 새로운 예약을 진행해 주세요."),
+    ACCESS_ONLY_REQUESTED_CUSTOMER("예약정보 조회는 예약을 요청한 고객만 가능합니다."),
+    ACCESS_ONLY_STORE_OWNER("해당 점포 점주만 가능한 기능입니다."),
+    NOT_FOUND_RESERVATION("예약 정보가 없습니다. 예약자명과 전화번호를 확인해주세요."),
+    NOT_RESERVATION_STORE("예약한 매장이 아닙니다."),
+    ENTRANCE_NOT_ON_TIME("도착 확인은 예약 시간 10분 전부터 가능합니다."),
+    TIME_OVER("입장 가능 시간이 지났습니다.");
 
 
     private final String description;

--- a/src/main/java/com/zerobase/mytable/type/ReservationStatus.java
+++ b/src/main/java/com/zerobase/mytable/type/ReservationStatus.java
@@ -1,0 +1,17 @@
+package com.zerobase.mytable.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReservationStatus {
+    WAITING("확정 대기"),
+    CONFIRM("확정"),
+    CANCEL("취소"),
+    DENIED("거절"),
+    ARRIVED("실행"),
+    NO_SHOW("미실행");
+
+    private final String msg;
+}

--- a/src/main/java/com/zerobase/mytable/type/Table.java
+++ b/src/main/java/com/zerobase/mytable/type/Table.java
@@ -1,0 +1,17 @@
+package com.zerobase.mytable.type;
+
+import lombok.*;
+import org.hibernate.annotations.GeneratorType;
+
+import javax.persistence.*;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Table {
+    private Integer tableVolume;
+    private Integer tableAmount;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,10 @@ spring.jpa.database=mysql
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernamte.format_ssql=true
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
 
 springboot.jwt.secret=table
+
+spring.profiles.include=api-key
+
+schedules.cron.check.no-show= 0 5 0 * * *

--- a/src/test/java/com/zerobase/mytable/service/ReservationServiceTest.java
+++ b/src/test/java/com/zerobase/mytable/service/ReservationServiceTest.java
@@ -1,0 +1,757 @@
+package com.zerobase.mytable.service;
+
+import com.zerobase.mytable.domain.Customer;
+import com.zerobase.mytable.domain.Partner;
+import com.zerobase.mytable.domain.Reservation;
+import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.dto.ReservationDto;
+import com.zerobase.mytable.exception.CustomException;
+import com.zerobase.mytable.repository.CustomerRepository;
+import com.zerobase.mytable.repository.ReservationRepository;
+import com.zerobase.mytable.repository.StoreRepository;
+import com.zerobase.mytable.security.TokenProvider;
+import com.zerobase.mytable.type.CommonResponse;
+import com.zerobase.mytable.type.ErrorCode;
+import com.zerobase.mytable.type.ReservationStatus;
+import net.nurigo.sdk.message.model.MessageType;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private CustomerRepository customerRepository;
+    @Mock
+    private TokenProvider tokenProvider;
+    @Mock
+    private SendMessageService sendMessageService;
+    @InjectMocks
+    private ReservationService reservationService;
+
+    // 예약 요청 성공 테스트
+    @Test
+    void successMakeReservation() {
+        //given
+        Partner partner = Partner.builder().phone("010-1111-1111").build();
+        Store store = Store.builder().partner(partner).build();
+        Customer customer = Customer.builder().build();
+        SingleMessageSentResponse singleMessageSentResponse =
+                new SingleMessageSentResponse("a", "b", "c",
+                        MessageType.MMS, "1", "2", "3",
+                        "4", "5");
+
+        Mockito.when(storeRepository.findByStorename(anyString()))
+                .thenReturn(Optional.of(store));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(customerRepository.getByUid(anyString()))
+                .thenReturn(customer);
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+        Mockito.when(sendMessageService.sendOneMessage(anyString(), anyString()))
+                .thenReturn(singleMessageSentResponse);
+        //when
+        String token = "abc";
+        ReservationDto request = ReservationDto.builder()
+                .date(LocalDate.of(2023, 12, 1))
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차 1호점")
+                .build();
+        CommonResponse response = reservationService.makeReservation(token, request);
+        //then
+        assertEquals(response, CommonResponse.SUCCESS);
+    }
+
+    // 예약 요청 시 해당 점포 없을 경우 예외처리
+    @Test
+    void makeReservation_NotFoundStore() {
+        //given
+        Mockito.when(storeRepository.findByStorename(anyString()))
+                .thenReturn(Optional.empty());
+        //when
+        String token = "abc";
+        ReservationDto request = ReservationDto.builder()
+                .date(LocalDate.of(2023, 12, 1))
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차 1호점")
+                .build();
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.makeReservation(token, request));
+        //then
+        assertEquals(ErrorCode.NOT_FOUND_STORE, customException.getErrorCode());
+    }
+
+    // 예약 요청 시 예약 시간이 현재 시간으로부터 한달을 경과할 경우 예외 처리
+    @Test
+    void makeReservation_ReservationDateMustBeInAMonth() {
+        //given
+        Store store = Store.builder().build();
+        Mockito.when(storeRepository.findByStorename(anyString()))
+                .thenReturn(Optional.of(store));
+        //when
+        String token = "abc";
+        ReservationDto request = ReservationDto.builder()
+                .date(LocalDate.now().plusMonths(2))
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차 1호점")
+                .build();
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.makeReservation(token, request));
+        //then
+        assertEquals(customException.getErrorCode(),
+                ErrorCode.RESERVATION_DATE_MUST_BE_IN_A_MONTH);
+    }
+
+    // 고객이 예약한 예약 리스트 조회 성공 테스트
+    @Test
+    void customerGetMyReservations() {
+        //given
+        Customer customer = mock(Customer.class);
+        Store store = Store.builder().storename("포장마차").build();
+
+        List<Reservation> reservations = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            LocalDate date = LocalDate.of(2023, 12, i);
+            Reservation reservation = Reservation.builder()
+                    .customer(customer)
+                    .uid(Integer.toString(i))
+                    .dateTime(LocalDateTime.of(date, LocalTime.MAX))
+                    .underName("abc")
+                    .phone("123")
+                    .store(store)
+                    .build();
+            reservations.add(reservation);
+        }
+
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(customerRepository.getByUid(anyString()))
+                .thenReturn(customer);
+        Mockito.when(customer.getReservations()).thenReturn(reservations);
+        //when
+        String token = "abc";
+        Page<ReservationDto> page = reservationService.customerGetMyReservations(
+                token, PageRequest.of(0, 5));
+        //then
+        for (int i = 0; i < reservations.size(); i++) {
+            assertEquals(page.getContent().get(i).getUid(),
+                    reservations.stream()
+                            .map(ReservationDto::from)
+                            .collect(Collectors.toList()).get(i).getUid());
+        }
+    }
+
+    // 고객 예약 상세정보 조회
+    @Test
+    void successCustomerGetReservation() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Customer customer = Customer.builder().uid("abc").build();
+        Store store = Store.builder().storename("포장마차").build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto reservationDto = reservationService.customerGetReservation(
+                token, reservationUid);
+        //then
+        assertEquals(reservationDto.getUid(), "1");
+        assertEquals(reservationDto.getDate(), now.toLocalDate());
+        assertEquals(reservationDto.getTime(), now.toLocalTime());
+        assertEquals(reservationDto.getUnderName(), "abc");
+        assertEquals(reservationDto.getPhone(), "123");
+        assertEquals(reservationDto.getStorename(), "포장마차");
+    }
+
+    // 고객 예약 상세정보 조회 시 찾고자 하는 예약 없을 때 예외 처리
+    @Test
+    void customerGetReservation_ReservationNotFound() {
+        //given
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.empty());
+
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.customerGetReservation(token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    // 고객 예약 상세정보 조회 시 예약요청 고객이 조회하려는 고객과 다른 경우 예외 처리
+    @Test
+    void customerGetReservation_AccessOnlyRequestedCustomer() {
+        //given
+        Customer customer = Customer.builder().uid("abc").build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("aaa");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.customerGetReservation(token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(),
+                ErrorCode.ACCESS_ONLY_REQUESTED_CUSTOMER);
+    }
+
+    // 고객 예약 수정 성공 테스트
+    @Test
+    void successUpdateReservation() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Customer customer = Customer.builder().uid("abc").build();
+        Partner partner = Partner.builder().phone("123").build();
+        Store store = Store.builder()
+                .storename("포장마차").partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+
+        SingleMessageSentResponse singleMessageSentResponse =
+                new SingleMessageSentResponse("a", "b", "c",
+                        MessageType.MMS, "1", "2", "3",
+                        "4", "5");
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+        Mockito.when(sendMessageService.sendOneMessage(anyString(), anyString()))
+                .thenReturn(singleMessageSentResponse);
+        //when
+        LocalDate tomorrow = now.toLocalDate().plusDays(1);
+
+        String token = "111";
+        String reservationUid = "123123";
+        ReservationDto request = ReservationDto.builder()
+                .date(tomorrow)
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차")
+                .build();
+        ReservationDto reservationDto = reservationService.updateReservation(
+                token, reservationUid, request);
+        //then
+        assertEquals(reservationDto.getDate(), tomorrow);
+        assertEquals(reservationDto.getTime(), LocalTime.of(16, 30));
+        assertEquals(reservationDto.getUnderName(), "홍길동");
+        assertEquals(reservationDto.getPhone(), "010-1111-1111");
+        assertEquals(reservationDto.getStorename(), "포장마차");
+        assertEquals(reservationDto.getStatus(), ReservationStatus.WAITING);
+    }
+
+    // 고객 예약 수정 시 찾고자 하는 예약 없을 때 예외 처리
+    @Test
+    void updateReservation_ReservationNotFound() {
+        //given
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.empty());
+
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto request = ReservationDto.builder()
+                .date(LocalDate.now())
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차")
+                .build();
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.updateReservation(
+                        token, reservationUid, request));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    // 고객 예약 수정 시 예약요청 고객이 수정하려는 고객과 다른 경우 예외 처리
+    @Test
+    void updateReservation_AccessOnlyRequestedCustomer() {
+        //given
+        Customer customer = Customer.builder().uid("abc").build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("aaa");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto request = ReservationDto.builder()
+                .date(LocalDate.now())
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차")
+                .build();
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.updateReservation(
+                        token, reservationUid, request));
+        //then
+        assertEquals(customException.getErrorCode(),
+                ErrorCode.ACCESS_ONLY_REQUESTED_CUSTOMER);
+    }
+
+    // 예약 수정 시 점포명 변경하려고 할 경우 예외 처리
+    @Test
+    void updateReservation_CannotUpdateStore() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Customer customer = Customer.builder().uid("abc").build();
+        Partner partner = Partner.builder().phone("123").build();
+        Store store = Store.builder()
+                .storename("포장마차").partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+
+        //when
+        LocalDate tomorrow = now.toLocalDate().plusDays(1);
+
+        String token = "111";
+        String reservationUid = "123123";
+        ReservationDto request = ReservationDto.builder()
+                .date(tomorrow)
+                .time(LocalTime.of(16, 30))
+                .underName("홍길동")
+                .phone("010-1111-1111")
+                .storename("포장마차 2호점")
+                .build();
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.updateReservation(
+                        token, reservationUid, request));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.CANNOT_UPDATE_STORE);
+    }
+
+    // 고객 예약 취소 성공 테스트
+    @Test
+    void successCancelReservation() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Customer customer = Customer.builder().uid("abc").build();
+        Store store = Store.builder().storename("포장마차").build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto reservationDto = reservationService.cancelReservation(
+                token, reservationUid);
+        //then
+        assertEquals(reservationDto.getUid(), "1");
+        assertEquals(reservationDto.getDate(), now.toLocalDate());
+        assertEquals(reservationDto.getTime(), now.toLocalTime());
+        assertEquals(reservationDto.getUnderName(), "abc");
+        assertEquals(reservationDto.getPhone(), "123");
+        assertEquals(reservationDto.getStorename(), "포장마차");
+        assertEquals(reservationDto.getStatus(), ReservationStatus.CANCEL);
+    }
+
+    // 고객 예약 삭제 시 찾고자 하는 예약 없을 때 예외 처리
+    @Test
+    void cancelReservation_ReservationNotFound() {
+        //given
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.empty());
+
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.cancelReservation(token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    // 고객 예약 상세정보 조회 시 예약요청 고객이 조회하려는 고객과 다른 경우 예외 처리
+    @Test
+    void cancelReservation_AccessOnlyRequestedCustomer() {
+        //given
+        Customer customer = Customer.builder().uid("abc").build();
+        Reservation reservation = Reservation.builder()
+                .customer(customer)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("aaa");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.cancelReservation(token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(),
+                ErrorCode.ACCESS_ONLY_REQUESTED_CUSTOMER);
+    }
+
+    // 파트너 예약 상세정보 조회 성공 테스트
+    @Test
+    void successPartnerGerReservation() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Partner partner = Partner.builder().uid("abc").build();
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto reservationDto = reservationService.partnerGetReservation(
+                token, reservationUid);
+        //then
+        assertEquals(reservationDto.getUid(), "1");
+        assertEquals(reservationDto.getDate(), now.toLocalDate());
+        assertEquals(reservationDto.getTime(), now.toLocalTime());
+        assertEquals(reservationDto.getUnderName(), "abc");
+        assertEquals(reservationDto.getPhone(), "123");
+        assertEquals(reservationDto.getStorename(), "포장마차");
+    }
+
+    // 파트너 예약 상세정보 조회 시 찾는 예약 없을 경우 예외 처리 테스트
+    @Test
+    void partnerGerReservation_ReservationNotFound() {
+        //given
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.empty());
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.partnerGetReservation(token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    // 파트너 예약 상세정보 조회 시 점주와 조회하려는 파트너가 다른 경우 예외 처리
+    @Test
+    void partnerGerReservation_AccessOnlyStoreOwner() {
+        //given
+        Partner partner = Partner.builder().uid("abc").build();
+        Store store = Store.builder()
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("aaa");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.partnerGetReservation(token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_ONLY_STORE_OWNER);
+    }
+
+    // 파트너 예약 승인 성공 테스트
+    @Test
+    void successPartnerReservationConfirm() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Partner partner = Partner.builder().uid("abc").phone("1234").build();
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+        SingleMessageSentResponse singleMessageSentResponse =
+                new SingleMessageSentResponse("a", "b", "c",
+                        MessageType.MMS, "1", "2", "3",
+                        "4", "5");
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+        Mockito.when(sendMessageService.sendOneMessage(anyString(), anyString()))
+                .thenReturn(singleMessageSentResponse);
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto reservationDto = reservationService.partnerReservationConfirm(
+                token, reservationUid);
+        //then
+        assertEquals(reservationDto.getUid(), "1");
+        assertEquals(reservationDto.getDate(), now.toLocalDate());
+        assertEquals(reservationDto.getTime(), now.toLocalTime());
+        assertEquals(reservationDto.getUnderName(), "abc");
+        assertEquals(reservationDto.getPhone(), "123");
+        assertEquals(reservationDto.getStorename(), "포장마차");
+        assertEquals(reservationDto.getStatus(), ReservationStatus.CONFIRM);
+    }
+
+    // 파트너 예약 승인 시 찾는 예약 없을 경우 예외 처리 테스트
+    @Test
+    void partnerReservationConfirm_ReservationNotFound() {
+        //given
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.empty());
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.partnerReservationConfirm(
+                        token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    // 파트너 예약 승인 시 점주와 조회하려는 파트너가 다른 경우 예외 처리
+    @Test
+    void partnerReservationConfirm_AccessOnlyStoreOwner() {
+        //given
+        Partner partner = Partner.builder().uid("abc").build();
+        Store store = Store.builder()
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("aaa");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.partnerReservationConfirm(
+                        token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_ONLY_STORE_OWNER);
+    }
+
+    // 파트너 예약 거절 성공 테스트
+    @Test
+    void successPartnerReservationReject() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Partner partner = Partner.builder().uid("abc").phone("1234").build();
+        Store store = Store.builder()
+                .storename("포장마차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(now)
+                .underName("abc")
+                .phone("123")
+                .store(store)
+                .build();
+        SingleMessageSentResponse singleMessageSentResponse =
+                new SingleMessageSentResponse("a", "b", "c",
+                        MessageType.MMS, "1", "2", "3",
+                        "4", "5");
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+        Mockito.when(sendMessageService.sendOneMessage(anyString(), anyString()))
+                .thenReturn(singleMessageSentResponse);
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        ReservationDto reservationDto = reservationService.partnerReservationReject(
+                token, reservationUid);
+        //then
+        assertEquals(reservationDto.getUid(), "1");
+        assertEquals(reservationDto.getDate(), now.toLocalDate());
+        assertEquals(reservationDto.getTime(), now.toLocalTime());
+        assertEquals(reservationDto.getUnderName(), "abc");
+        assertEquals(reservationDto.getPhone(), "123");
+        assertEquals(reservationDto.getStorename(), "포장마차");
+        assertEquals(reservationDto.getStatus(), ReservationStatus.DENIED);
+    }
+
+    // 파트너 예약 거절 시 찾는 예약 없을 경우 예외 처리 테스트
+    @Test
+    void partnerReservationReject_ReservationNotFound() {
+        //given
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.empty());
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.partnerReservationReject(
+                        token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.RESERVATION_NOT_FOUND);
+    }
+
+    // 파트너 예약 승인 시 점주와 조회하려는 파트너가 다른 경우 예외 처리
+    @Test
+    void partnerReservationReject_AccessOnlyStoreOwner() {
+        //given
+        Partner partner = Partner.builder().uid("abc").build();
+        Store store = Store.builder()
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .store(store)
+                .build();
+
+        Mockito.when(reservationRepository.findByUid(anyString()))
+                .thenReturn(Optional.of(reservation));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("aaa");
+        //when
+        String token = "1111";
+        String reservationUid = "1";
+        CustomException customException = assertThrows(CustomException.class,
+                () -> reservationService.partnerReservationReject(
+                        token, reservationUid));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_ONLY_STORE_OWNER);
+    }
+
+    // 매일 00시 05분에 예약 상태 confirm인 건(도착확인 안 된 건)들 NO_SHOW로 변경 성공 테스트
+    @Test
+    void successCheckReservationNoShow() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        List<Reservation> reservations = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            reservations.add(Reservation.builder()
+                    .uid(Integer.toString(i))
+                    .status(ReservationStatus.CONFIRM)
+                    .dateTime(now)
+                    .build());
+        }
+
+        Mockito.when(reservationRepository.findAllByStatusAndDateTimeBefore(
+                any(), any()))
+                .thenReturn(reservations);
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+
+        //when
+        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+
+        reservationService.checkReservationNoShow();
+        //then
+        verify(reservationRepository, times(3))
+                .save(captor.capture());
+        List<Reservation> captureList = captor.getAllValues();
+        assertEquals(captureList.get(0).getUid(), "0") ;
+        assertEquals(captureList.get(1).getUid(), "1") ;
+        assertEquals(captureList.get(2).getUid(), "2") ;
+        assertEquals(captureList.get(0).getStatus(), ReservationStatus.NO_SHOW) ;
+        assertEquals(captureList.get(1).getStatus(), ReservationStatus.NO_SHOW) ;
+        assertEquals(captureList.get(2).getStatus(), ReservationStatus.NO_SHOW) ;
+    }
+
+}

--- a/src/test/java/com/zerobase/mytable/service/SendMessageServiceTest.java
+++ b/src/test/java/com/zerobase/mytable/service/SendMessageServiceTest.java
@@ -1,0 +1,31 @@
+package com.zerobase.mytable.service;
+
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class SendMessageServiceTest {
+
+    @Autowired
+    private SendMessageService sendMessageService;
+
+    @Value(value = "${caller.number}")
+    private String callerNumber;
+
+    // 문자 발송 테스트
+    @Test
+    void successSendMessage() {
+        //given
+
+        //when
+        SingleMessageSentResponse response =
+                sendMessageService.sendOneMessage(callerNumber, "test message");
+        //then
+        assertEquals("정상 접수(이통사로 접수 예정) ".trim(), response.getStatusMessage().trim());
+    }
+}

--- a/src/test/java/com/zerobase/mytable/service/StoreServiceTest.java
+++ b/src/test/java/com/zerobase/mytable/service/StoreServiceTest.java
@@ -1,28 +1,41 @@
 package com.zerobase.mytable.service;
 
 import com.zerobase.mytable.domain.Partner;
+import com.zerobase.mytable.domain.Reservation;
 import com.zerobase.mytable.domain.Store;
+import com.zerobase.mytable.dto.ReservationDto;
 import com.zerobase.mytable.dto.StoreDto;
 import com.zerobase.mytable.dto.StoreRegisterDto;
 import com.zerobase.mytable.exception.CustomException;
 import com.zerobase.mytable.repository.PartnerRepository;
+import com.zerobase.mytable.repository.ReservationRepository;
 import com.zerobase.mytable.repository.StoreRepository;
 import com.zerobase.mytable.security.TokenProvider;
+import com.zerobase.mytable.type.Address;
+import com.zerobase.mytable.type.CommonResponse;
 import com.zerobase.mytable.type.ErrorCode;
+import com.zerobase.mytable.type.ReservationStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class StoreServiceTest {
@@ -32,6 +45,9 @@ class StoreServiceTest {
 
     @Mock
     private PartnerRepository partnerRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
 
     @Mock
     private TokenProvider tokenProvider;
@@ -123,10 +139,12 @@ class StoreServiceTest {
         Store store = Store.builder()
                 .storename("포장마차")
                 .phone("02-111-1111")
-                .sido("경기도")
-                .sigungu("군포시")
-                .roadname("번영로")
-                .detailAddress("행복한 곳")
+                .address(Address.builder()
+                        .sido("경기도")
+                        .sigungu("군포시")
+                        .roadname("번영로")
+                        .detailAddress("행복한 곳")
+                        .build())
                 .description("맛있는 가게")
                 .build();
 
@@ -137,10 +155,10 @@ class StoreServiceTest {
         //then
         assertEquals(response.getStorename(), "포장마차");
         assertEquals(response.getPhone(), "02-111-1111");
-        assertEquals(response.getSido(), "경기도");
-        assertEquals(response.getSigungu(), "군포시");
-        assertEquals(response.getRoadname(), "번영로");
-        assertEquals(response.getDetailAddress(), "행복한 곳");
+        assertEquals(response.getAddress().getSido(), "경기도");
+        assertEquals(response.getAddress().getSigungu(), "군포시");
+        assertEquals(response.getAddress().getRoadname(), "번영로");
+        assertEquals(response.getAddress().getDetailAddress(), "행복한 곳");
         assertEquals(response.getDescription(), "맛있는 가게");
     }
 
@@ -188,10 +206,10 @@ class StoreServiceTest {
         //then
         assertEquals(storeDto.getStorename(), "포차");
         assertEquals(storeDto.getPhone(), "02-111-1111");
-        assertEquals(storeDto.getSido(), "경기도");
-        assertEquals(storeDto.getSigungu(), "군포시");
-        assertEquals(storeDto.getRoadname(), "번영로");
-        assertEquals(storeDto.getDetailAddress(), "행복한 곳");
+        assertEquals(storeDto.getAddress().getSido(), "경기도");
+        assertEquals(storeDto.getAddress().getSigungu(), "군포시");
+        assertEquals(storeDto.getAddress().getRoadname(), "번영로");
+        assertEquals(storeDto.getAddress().getDetailAddress(), "행복한 곳");
         assertEquals(storeDto.getDescription(), "맛있는 가게");
     }
 
@@ -333,4 +351,340 @@ class StoreServiceTest {
         assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_DENIED);
     }
 
+    // 점주가 관리하는 점포 리스트 조회
+    @Test
+    void successGetMyStores() {
+        //given
+        Partner partner = mock(Partner.class);
+        List<Store> stores = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            Store store = Store.builder()
+                    .storename(i + "호점")
+                    .build();
+            store.setCreatedAt(LocalDateTime.now().minusDays(i));
+            stores.add(store);
+        }
+
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(partnerRepository.getByUid(anyString()))
+                .thenReturn(partner);
+        Mockito.when(partner.getStores()).thenReturn(stores);
+        //when
+        String token = "abc";
+        Page<StoreDto> page = storeService.getMyStores(token, PageRequest.of(0, 5));
+        //then
+        assertEquals(page.getContent().get(0).getStorename(), "3호점");
+        assertEquals(page.getContent().get(1).getStorename(), "2호점");
+        assertEquals(page.getContent().get(2).getStorename(), "1호점");
+    }
+
+    // 파트너 점포 별 예약 조회 성공 테스트
+    @Test
+    void successGetReservationsByStore() {
+        //given
+        Store store = mock(Store.class);
+        Partner partner = Partner.builder().uid("abc").build();
+        LocalDateTime now = LocalDateTime.now();
+        List<Reservation> reservations = new ArrayList<>();
+        int days = 1;
+        for (int i = 1; i <= 4; i++) {
+            if (i == 3) {
+                days--;
+            }
+            Reservation reservation = Reservation.builder()
+                    .uid(Integer.toString(i))
+                    .dateTime(now.minusDays(days++))
+                    .underName("홍길동")
+                    .phone("123")
+                    .store(store)
+                    .build();
+            reservation.setCreatedAt(now.minusMonths(1).plusDays(i));
+            reservations.add(reservation);
+        }
+
+        Mockito.when(storeRepository.findByStorename(anyString()))
+                .thenReturn(Optional.of(store));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("abc");
+        Mockito.when(store.getReservations()).thenReturn(reservations);
+        Mockito.when(store.getPartner()).thenReturn(partner);
+        Mockito.when(store.getStorename()).thenReturn("포차");
+        //when
+        Page<ReservationDto> page = storeService.getReservationsByStore(
+                "111", "포장마차", now.toLocalDate().minusMonths(1),
+                now.toLocalDate().plusMonths(1),
+                PageRequest.of(0, 5));
+        //then
+        assertEquals(page.getContent().get(0).getUid(), "4");
+        assertEquals(page.getContent().get(1).getUid(), "2");
+        assertEquals(page.getContent().get(2).getUid(), "3");
+        assertEquals(page.getContent().get(3).getUid(), "1");
+    }
+
+    // 파트너 점포 별 예약 조회 시 해당 점포 없을 경우 예외 처리
+    @Test
+    void getReservationsByStore_NotFoundStore() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Mockito.when(storeRepository.findByStorename(anyString()))
+                .thenReturn(Optional.empty());
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.getReservationsByStore(
+                        "111", "포장마차", now.toLocalDate().minusMonths(1),
+                        now.toLocalDate().plusMonths(1),
+                        PageRequest.of(0, 5)));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_STORE);
+    }
+
+    // 파트너 점포 별 예약 조회 시 조회하려는 파트너와 해당 점주가 다를 경우 예외 처리
+    @Test
+    void getReservationsByStore_AccessDenied() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Partner partner = Partner.builder().uid("abc").build();
+        Store store = Store.builder().partner(partner).build();
+
+        Mockito.when(storeRepository.findByStorename(anyString()))
+                .thenReturn(Optional.of(store));
+        Mockito.when(tokenProvider.getUid(anyString()))
+                .thenReturn("123");
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.getReservationsByStore(
+                        "111", "포장마차", now.toLocalDate().minusMonths(1),
+                        now.toLocalDate().plusMonths(1),
+                        PageRequest.of(0, 5)));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_DENIED);
+    }
+
+    // 파트너 키오스크에서 예약자명과 전화번호를 통해 예약 검색 성공 테스트
+    @Test
+    void successSearchReservation() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder()
+                .storename("포차")
+                .partner(partner).build();
+
+        List<Reservation> reservations = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            Reservation reservation = Reservation.builder()
+                    .uid(Integer.toString(i))
+                    .dateTime(now.minusDays(i))
+                    .underName("홍길동")
+                    .phone("123")
+                    .store(store)
+                    .build();
+            reservations.add(reservation);
+        }
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("123");
+        given(reservationRepository.findAllByUnderNameAndPhoneAndStoreAndStatus(
+                "홍길동", "123", store, ReservationStatus.CONFIRM))
+                .willReturn(reservations);
+        //when
+        Page<ReservationDto> page = storeService.searchReservation(
+                "abc", "포차", "홍길동",
+                "123", PageRequest.of(0, 5));
+        //then
+        assertEquals(page.getContent().get(0).getUid(), "3");
+        assertEquals(page.getContent().get(1).getUid(), "2");
+        assertEquals(page.getContent().get(2).getUid(), "1");
+    }
+
+    // 파트너 키오스크에서 예약 검색 시 없는 점포일 경우 예외처리
+    @Test
+    void searchReservation_NotFoundStore() {
+        //given
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.searchReservation(
+                "abc", "포차", "홍길동",
+                "123", PageRequest.of(0, 5)));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_STORE);
+    }
+
+    // 파트너 키오스크에서 예약 검색 시 점주와 예약검색 요청한 파트너가 다를 경우 예외처리
+    @Test
+    void searchReservation_AccessDenied() {
+        //given
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder().partner(partner).build();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("abc");
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.searchReservation(
+                        "abc", "포차", "홍길동",
+                        "123", PageRequest.of(0, 5)));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_DENIED);
+    }
+
+    // 파트너 키오스크에서 예약 검색 시 조회되는 예약 없을 경우 예외 처리
+    @Test
+    void searchReservation_NotFoundReservation() {
+        //given
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder()
+                .storename("포차")
+                .partner(partner).build();
+
+        List<Reservation> reservations = new ArrayList<>();
+
+        given(storeRepository.findByStorename(anyString()))
+                .willReturn(Optional.of(store));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("123");
+        given(reservationRepository.findAllByUnderNameAndPhoneAndStoreAndStatus(
+                "홍길동", "123", store, ReservationStatus.CONFIRM))
+                .willReturn(reservations);
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.searchReservation(
+                        "abc", "포차", "홍길동",
+                        "123", PageRequest.of(0, 5)));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_RESERVATION);
+    }
+
+    // 파트너 키오스크에서 예약 도착 확인 성공 테스트
+    @Test
+    void successArrivalConfirm() {
+        //given
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder()
+                .storename("포차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(LocalDateTime.now().plusMinutes(5))
+                .underName("홍길동")
+                .phone("123")
+                .store(store)
+                .build();
+
+        given(reservationRepository.findByUid(anyString()))
+                .willReturn(Optional.of(reservation));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("123");
+        Mockito.when(reservationRepository.save(any(Reservation.class)))
+                .then(returnsFirstArg());
+        //when
+        CommonResponse commonResponse = storeService.arrivalConfirm(
+                "123", "123");
+        //then
+        assertEquals(commonResponse, CommonResponse.SUCCESS);
+    }
+
+    // 파트너 키오스크에서 예약 도착 확인 시 해당 예약 건 없을 때 예외 처리
+    @Test
+    void arrivalConfirm_NotFoundReservation() {
+        //given
+        given(reservationRepository.findByUid(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.arrivalConfirm("123", "123"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.NOT_FOUND_RESERVATION);
+    }
+
+    // 파트너 키오스크에서 예약 도착 확인 시 점주와 예약 확정 요청하는 파트너가 다를 경우 예외 처리
+    @Test
+    void arrivalConfirm_AccessDenied() {
+        //given
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder()
+                .storename("포차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(LocalDateTime.now().plusMinutes(5))
+                .underName("홍길동")
+                .phone("123")
+                .store(store)
+                .build();
+
+        given(reservationRepository.findByUid(anyString()))
+                .willReturn(Optional.of(reservation));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("abc");
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.arrivalConfirm("123", "123"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ACCESS_DENIED);
+    }
+
+    // 파트너 키오스크에서 예약 도착 확인 시 도착 확인 요청 시간이 예약시간 10분 내가 아닌 경우 예외 처리
+    @Test
+    void arrivalConfirm_EntranceNotOnTime() {
+        //given
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder()
+                .storename("포차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(LocalDateTime.now().plusMinutes(15))
+                .underName("홍길동")
+                .phone("123")
+                .store(store)
+                .build();
+
+        given(reservationRepository.findByUid(anyString()))
+                .willReturn(Optional.of(reservation));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("123");
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.arrivalConfirm("123", "123"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.ENTRANCE_NOT_ON_TIME);
+    }
+
+    // 파트너 키오스크에서 예약 도착 확인 시 도착 확인 요청 시간이 예약시간 10분 경과한 경우 예외 처리
+    @Test
+    void arrivalConfirm_TimeOver() {
+        //given
+        Partner partner = Partner.builder().uid("123").build();
+        Store store = Store.builder()
+                .storename("포차")
+                .partner(partner).build();
+        Reservation reservation = Reservation.builder()
+                .uid("1")
+                .dateTime(LocalDateTime.now().minusMinutes(15))
+                .underName("홍길동")
+                .phone("123")
+                .store(store)
+                .build();
+
+        given(reservationRepository.findByUid(anyString()))
+                .willReturn(Optional.of(reservation));
+        given(tokenProvider.getUid(anyString()))
+                .willReturn("123");
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+                () -> storeService.arrivalConfirm("123", "123"));
+        //then
+        assertEquals(customException.getErrorCode(), ErrorCode.TIME_OVER);
+    }
 }
+
+

--- a/src/test/java/com/zerobase/mytable/testutil/WithMockCustomUser.java
+++ b/src/test/java/com/zerobase/mytable/testutil/WithMockCustomUser.java
@@ -1,0 +1,13 @@
+package com.zerobase.mytable.testutil;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String userName() default "user";
+    String role() default "ROLE_PARTNER";
+}

--- a/src/test/java/com/zerobase/mytable/testutil/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/zerobase/mytable/testutil/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,22 @@
+package com.zerobase.mytable.testutil;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+        final UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(annotation.userName(), "",
+                List.of(new SimpleGrantedAuthority(annotation.role())));
+
+        securityContext.setAuthentication(authenticationToken);
+        return securityContext;
+    }
+}


### PR DESCRIPTION
Changes
---
1. 고객 예약 요청 기능
2. 고객의 예약 리스트 확인 기능
3. 고객 예약정보 상세 조회 기능
4. 고객 예약 수정 기능
5. 고객 예약 취소 기능
6. 파트너 예약 승인 기능
7. 파트너 예약 거절 기능
8. 파트너가 관리하는 점포 리스트 조회 기능
9. 점포 별 예약리스트 조회 기능(파트너)
10. 파트너의 점포에 해당하는 예약정보 상세 조회 기능
11. 키오스크에서 예약 검색 기능(키오스크는 파트너로 로그인 필요)
12. 키오스크에서 도착 확인 기능(키오스크는 파트너로 로그인 필요)
13. 각 기능 시나리오 별 테스트 코드 작성

기존 수정사항
---
1. Store 엔티티에 Address객체를 이용(embedded type)
2. Store 엔티티, Reservation 엔티티 일대다 양방향 매핑
3. Partner 엔티티, Store엔티티 일대다 양방향 매핑 
4. Customer 엔티티, Reservation 엔티티 일대다 양방향 매핑